### PR TITLE
Bump to 3.1.3 and onnxscript dependency

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -2,7 +2,7 @@
 schema_version: 1
 
 context:
-  version: "3.1.2"
+  version: "3.1.3"
 
 package:
   name: rsl-rl-lib
@@ -10,7 +10,7 @@ package:
 
 source:
   - url: https://pypi.org/packages/source/r/rsl-rl-lib/rsl_rl_lib-${{ version }}.tar.gz
-    sha256: dd808981c89b036f9dc610ddddf3df0ed501cd2c27146e0044b1000900363a1c
+    sha256: 93faa0b42ec2004803a1bff301eeca0bb425d670dcc7213610a475f470b13da7
 
 build:
   script: ${{ PYTHON }} -m pip install --no-deps --no-build-isolation .
@@ -31,6 +31,7 @@ requirements:
     - numpy >=1.16.4
     - gitpython
     - onnx
+    - onnxscript >=0.5.4
 
 tests:
   - python:


### PR DESCRIPTION
See https://github.com/leggedrobotics/rsl_rl/pull/127 .

Fix https://github.com/conda-forge/rsl-rl-lib-feedstock/pull/9 .

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
